### PR TITLE
use os.walk instead of glob - glob not searching mounted docker volume subdirectories

### DIFF
--- a/linter/lookml_project_parser.py
+++ b/linter/lookml_project_parser.py
@@ -24,7 +24,6 @@ class LookMlProjectParser:
         self.parsed_lookml_files = {}
 
         for filepath in lkml_filepaths:
-            print(f"filepath {filepath}")
 
             if not os.path.exists(filepath):
                 raise IOError("Filename does not exist: %s" % filepath)

--- a/linter/lookml_project_parser.py
+++ b/linter/lookml_project_parser.py
@@ -1,25 +1,25 @@
 import os
 import lkml
-import glob
-import argparse
 
 
 class LookMlProjectParser:
-
-
     def __init__(self, lkml_dir: str) -> None:
-        '''parse a list of LookML filepaths and then read into dictionary object
+        """parse a list of LookML filepaths and then read into dictionary object
         Args:
             infilepath (list): list of input LookML file paths
         Returns:
 
-        '''
+        """
         self.lkml_dir = lkml_dir
         if os.path.isdir(self.lkml_dir):
-            lkml_filepaths = [os.path.join(dp, f) for dp, dn, filenames in os.walk(self.lkml_dir) for f in filenames if os.path.splitext(f)[1] == '.lkml'] #use instead of glob - glob not searching mounted docker volume subdirectories 
+            lkml_filepaths = [
+                os.path.join(dp, f)
+                for dp, dn, filenames in os.walk(self.lkml_dir)
+                for f in filenames
+                if os.path.splitext(f)[1] == ".lkml"
+            ]  # use instead of glob - glob not searching mounted docker volume subdirectories
         else:
-            raise IOError("Directory does not exist: %s" %
-                          self.lkml_dir)
+            raise IOError("Directory does not exist: %s" % self.lkml_dir)
         self.unparsable_lookml_files = []
         self.parsed_lookml_files = {}
 
@@ -28,7 +28,7 @@ class LookMlProjectParser:
             if not os.path.exists(filepath):
                 raise IOError("Filename does not exist: %s" % filepath)
 
-            with open(filepath, 'r') as file:
+            with open(filepath, "r") as file:
                 try:
                     self.parsed_lookml_files[filepath] = lkml.load(file)
                 except SyntaxError:

--- a/linter/lookml_project_parser.py
+++ b/linter/lookml_project_parser.py
@@ -1,6 +1,7 @@
 import os
 import lkml
 import glob
+import argparse
 
 
 class LookMlProjectParser:
@@ -14,10 +15,8 @@ class LookMlProjectParser:
 
         '''
         self.lkml_dir = lkml_dir
-
         if os.path.isdir(self.lkml_dir):
-            lkml_filepaths = [f for f in glob.glob(
-                self.lkml_dir + "**/*.lkml", recursive=True)]
+            lkml_filepaths = [os.path.join(dp, f) for dp, dn, filenames in os.walk(self.lkml_dir) for f in filenames if os.path.splitext(f)[1] == '.lkml'] #use instead of glob - glob not searching mounted docker volume subdirectories 
         else:
             raise IOError("Directory does not exist: %s" %
                           self.lkml_dir)
@@ -25,6 +24,7 @@ class LookMlProjectParser:
         self.parsed_lookml_files = {}
 
         for filepath in lkml_filepaths:
+            print(f"filepath {filepath}")
 
             if not os.path.exists(filepath):
                 raise IOError("Filename does not exist: %s" % filepath)

--- a/linter/lookml_project_parser.py
+++ b/linter/lookml_project_parser.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import lkml
 
@@ -12,12 +13,8 @@ class LookMlProjectParser:
         """
         self.lkml_dir = lkml_dir
         if os.path.isdir(self.lkml_dir):
-            lkml_filepaths = [
-                os.path.join(dp, f)
-                for dp, dn, filenames in os.walk(self.lkml_dir)
-                for f in filenames
-                if os.path.splitext(f)[1] == ".lkml"
-            ]  # use instead of glob - glob not searching mounted docker volume subdirectories
+            pattern = os.path.join(self.lkml_dir, "**", "*.lkml")
+            lkml_filepaths = glob.glob(pattern, recursive=True)
         else:
             raise IOError("Directory does not exist: %s" % self.lkml_dir)
         self.unparsable_lookml_files = []

--- a/scripts/lookmllint
+++ b/scripts/lookmllint
@@ -7,21 +7,20 @@ from linter.lookml_project_parser import LookMlProjectParser
 
 
 def main():
-    config_file = os.environ["INPUT_CONFIGFILE"]
-    # path = os.environ['INPUT_LOOKMLPROJECT']
+    config_file = os.environ['INPUT_CONFIGFILE']
+    lkml_dir = os.environ.get('INPUT_LOOKMLPROJECT', "./")
 
     validator = ConfigValidator(config_file)
     validator.validate()
     config = validator.config
     rules = RulesEngine(config).rules
-    # LookMlProjectParser.root_file_path = path
-    data = LookMlProjectParser().get_parsed_lookml_files()
+    parser = LookMlProjectParser(lkml_dir)
+    data = parser.get_parsed_lookml_files()
     linter = LookMlLinter(data, rules)
+    print(f"running linter on following directory {lkml_dir}")
     linter.run()
     linter.print_errors()
-    assert (
-        linter.has_errors == False
-    ), "LookML Linter detected an error warning, please resolve any error warning to complete Pull Request"
+    assert linter.has_errors == False, "LookML Linter detected an error warning, please resolve any error warning to complete Pull Request"
 
 
 main()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setuptools.setup(
     description="Linting tool to enforce LookML best practices",
     long_description=pathlib.Path("README.md").read_text(),
     long_description_content_type="text/markdown",
-    url="https://github.com/rudo-ro/lookml-linter",
+    url="https://github.com/HealthByRo/lookml-linter",
     packages=setuptools.find_packages(),
     py_modules=["linter"],
     scripts=["scripts/lookmllint"],


### PR DESCRIPTION
Working when launching via  emulated github action docker environment as follows with files placed in `changed-files` subdirectory.

```
docker build -t lookml-linter .
docker run --rm -e INPUT_LOOKMLPROJECT=/github/workspace/changed-files -e INPUT_CONFIGFILE=/github/workspace/linter.config.yaml -v $(pwd):/github/workspace lookml-linter 
```

An issue I'm seeing with this when testing locally is;

```
Traceback (most recent call last):
  File "/Users/rudoterry/tmp/lookml-linter/env/bin/lookmllint", line 27, in <module>
    main()
  File "/Users/rudoterry/tmp/lookml-linter/env/bin/lookmllint", line 18, in main
    data = LookMlProjectParser().get_parsed_lookml_files()
TypeError: __init__() missing 1 required positional argument: 'lkml_dir'
```

However that does not match line 18 of this version that is being deployed. Need to understand what the issue is- some kind of caching I'm not aware of?? 🤔 