### PR TITLE
generate lookml field syntax on error

### DIFF
--- a/linter/lookml_linter.py
+++ b/linter/lookml_linter.py
@@ -1,4 +1,3 @@
-
 from typing import Dict, List, TypedDict
 from linter.helpers import pascal_case_to_snake_case
 from linter.rule import Rule, Severity
@@ -20,44 +19,46 @@ class LookMlLinter:
 
         for filename in self.data:
             file_data = self.data[filename]
-            views = file_data.get('views', [])
-            explores = file_data.get('explores', [])
-            self._errors.append({
-                'filename': filename,
-                'messages': []
-            })
+            views = file_data.get("views", [])
+            explores = file_data.get("explores", [])
+            self._errors.append({"filename": filename, "messages": []})
 
             for v in views:
-                self.__lint_object(v, 'view')
+                self.__lint_object(v, "view")
                 dimensions, measures, dimension_groups = [
-                    v.get(key, []) for key in ['dimensions', 'measures', 'dimension_groups']]
+                    v.get(key, [])
+                    for key in ["dimensions", "measures", "dimension_groups"]
+                ]
                 for d in dimensions:
-                    self.__lint_object(d, 'dimension')
+                    self.__lint_object(d, "dimension")
                 for g in dimension_groups:
-                    self.__lint_object(g, 'dimension_group')
+                    self.__lint_object(g, "dimension_group")
                 for m in measures:
-                    self.__lint_object(m, 'measure')
+                    self.__lint_object(m, "measure")
 
             for e in explores:
-                self.__lint_object(e, 'explore')
+                self.__lint_object(e, "explore")
 
     def print_errors(self) -> None:
         for error in self._errors:
-            print(error['filename'])
-            if len(error['messages']) == 0:
-                print(f'    No linting warnings/errors found.')
-            for message in error['messages']:
-                print(f'    {message}')
+            print(error["filename"])
+            if len(error["messages"]) == 0:
+                print(f"    No linting warnings/errors found.")
+            for message in error["messages"]:
+                print(f"    {message}")
             print()
 
     def __lint_object(self, object: Dict, object_type: str) -> None:
         if object_type in self.rules:
             for rule in self.rules[object_type]:
-                runner = rule['instance']
+                runner = rule["instance"]
                 if runner.severity != Severity.IGNORE.value:
                     success = runner.run(object)
                     if not success:
-                        if not self.has_errors and runner.severity == 'error':
+                        if not self.has_errors and runner.severity == "error":
                             self.has_errors = True
-                        error_msg = f'{runner.severity}: {object_type} {object["name"]} - {rule["name"]}'
-                        self._errors[-1]['messages'].append(error_msg)
+                        error_hint = runner.get_hint(object, object_type)
+                        print(error_hint)
+                        error_msg = f'{runner.severity}: {object_type} {object["name"]} - {rule["name"]} \n {error_hint}'
+                        
+                        self._errors[-1]["messages"].append(error_msg)

--- a/linter/rule.py
+++ b/linter/rule.py
@@ -15,6 +15,9 @@ class ParamSet(TypedDict):
 
 
 class Rule(ABC):
+
+    hint = ""
+
     @staticmethod
     @abstractmethod
     def applies_to() -> Tuple[str, ...]:
@@ -27,3 +30,6 @@ class Rule(ABC):
     @abstractmethod
     def run(self, lookml_object) -> bool:
         pass
+
+    def get_hint(self, lookml_object, object_type):
+        return self.hint

--- a/linter/rules/field_sql_html_requires_user_attribute_when_search_terms_found_exact.py
+++ b/linter/rules/field_sql_html_requires_user_attribute_when_search_terms_found_exact.py
@@ -1,20 +1,67 @@
+from pprint import pprint
 from linter.rule import Rule
 
 
 class FieldSqlHtmlRequiresUserAttributeWhenSearchTermsFoundExact(Rule):
     def applies_to():
-        return ('dimension', 'measure', 'dimension_group')
+        return ("dimension", "measure", "dimension_group")
 
     def run(self, field):
-        user_attribute = self.params['user_attribute']
-        search_terms = self.params['search_terms']
-        search_pattern = ' '.join([field.get(key, '')
-                                   for key in ['name', 'label', 'description']])
+        user_attribute = self.params["user_attribute"]
+        search_terms = self.params["search_terms"]
+        search_pattern = " ".join(
+            [field.get(key, "") for key in ["name", "label", "description"]]
+        )
         user_attribute_search_term = f'_user_attributes["{user_attribute}"]'
         search_terms_match_in_name_label_description = any(
-            [word == search_pattern.strip() for word in search_terms])
-        user_attribute_check_in_sql_html = not all([user_attribute_search_term in string for
-                                                    string in [field.get('sql', ''), field.get('html', '')]])
-        if search_terms_match_in_name_label_description and user_attribute_check_in_sql_html:
+            [word == search_pattern.strip() for word in search_terms]
+        )
+        user_attribute_check_in_sql_html = not all(
+            [
+                user_attribute_search_term in string
+                for string in [field.get("sql", ""), field.get("html", "")]
+            ]
+        )
+        if (
+            search_terms_match_in_name_label_description
+            and user_attribute_check_in_sql_html
+        ):
             return False
         return True
+
+    def get_hint(self, field, object_type):
+        search_pattern = " ".join(
+            [field.get(key, "") for key in ["name", "label", "description"]]
+        )
+        matched_user_attribute = [
+            self.params["user_attribute"]
+            for word in self.params["search_terms"]
+            if word == search_pattern.strip()
+        ][0]
+        pprint(field)
+        hint = f"""*** error hint: replace lkml field definition with the following (include _hidden field if it does not already exist. ensure type, sql and other attributes are set correctly): ***
+        
+
+        {object_type}: {field['name']}_hidden {{
+            group_label: "THISSHOULDBEHIDDEN"
+            hidden: yes
+            sql: ${{TABLE}}.{field['name']}
+            type: {field['type']}
+        }}
+
+        {object_type}: {field['name']} {{
+        sql:
+            CASE WHEN {{ _user_attributes["{matched_user_attribute}"] }} = 1 THEN
+                ${{{field['name']}_hidden}}
+            ELSE
+                -1
+            END ;;
+        html:
+            {{% if _user_attributes["{matched_user_attribute}"] == 1 %}}
+            <a href="#drillmenu" target="_self"> {{ rendered_value }}
+            {{% else %}}
+            [Insufficient Permissions]
+            {{% endif %}} ;;
+        }}"""
+
+        return hint


### PR DESCRIPTION
This functionality generates the fields for `.lkml` files when required permissions have not been set for a given field as according to [linter.config.yaml](https://github.com/HealthByRo/LookerRoMain/blob/master/linter.config.yaml). This gives a much clearer template for analysts to copy and paste into lkml and enables analysts less fmailiar with the prior lkmlgen setup to get up to speed on the current process for managing the permissions.

Explored various `lkml` documents in order to get the syntax right

```
        measure: sum_credits_amount_used_hidden {
            group_label: "THISSHOULDBEHIDDEN"
            hidden: yes
            sql: ${TABLE}.sum_credits_amount_used
            type: number
        }

        measure: sum_credits_amount_used {
        sql:
            CASE WHEN { _user_attributes["permissions_financial"] } = 1 THEN
                ${sum_credits_amount_used_hidden}
            ELSE
                -1
            END ;;
        html:
            {% if _user_attributes["permissions_financial"] == 1 %}
            <a href="#drillmenu" target="_self"> { rendered_value }
            {% else %}
            [Insufficient Permissions]
            {% endif %} ;;
        }
```

**Need to validate this sql is correct - this is validated as working in the looker panel**